### PR TITLE
Remove second box definition

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -77,7 +77,6 @@ Vagrant.configure(2) do |config|
   #SHELL
 
   #   /home/vagrant/localperl/bin/perl /vagrant/install.pl test
-  config.vm.box = "hashicorp/precise32"
   config.vm.provision "shell", inline: <<-SHELL
      /usr/bin/perl /vagrant/install.pl
      /home/vagrant/localperl/bin/perl -v


### PR DESCRIPTION
There should be only one config.vm.box definition for a VM.
