### PR TITLE
Fix

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,7 +67,7 @@ Vagrant.configure(2) do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell", path: "bootstrap.sh"
+  config.vm.provision "shell", :privileged => false, path: "bootstrap.sh"
   #config.vm.provision "shell", inline: <<-SHELL
   #  sudo apt-get update
   #  sudo apt-get install -y htop

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,30 +1,30 @@
 #!/usr/bin/env bash
 
-apt-get update
-apt-get upgrade
-apt-get autoremove -y
-apt-get install -y htop
-apt-get install -y tree
-apt-get install -y vim
-apt-get install -y curl
-apt-get install -y git
-apt-get install -y mongodb
-#apt-get install -y libxml2
-apt-get install -y libxml2-dev
-apt-get install -y libexpat1-dev
-apt-get install -y libpam-dev
-apt-get install -y libdb-dev
-apt-get install -y redis-server
-apt-get install -y sqlite3
-apt-get install -y libsqlite3-dev
-apt-get install -y libssl-dev
-apt-get install -y elasticsearch
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt-get autoremove -y
+sudo apt-get install -y htop
+sudo apt-get install -y tree
+sudo apt-get install -y vim
+sudo apt-get install -y curl
+sudo apt-get install -y git
+sudo apt-get install -y mongodb
+#sudo apt-get install -y libxml2
+sudo apt-get install -y libxml2-dev
+sudo apt-get install -y libexpat1-dev
+sudo apt-get install -y libpam-dev
+sudo apt-get install -y libdb-dev
+sudo apt-get install -y redis-server
+sudo apt-get install -y sqlite3
+sudo apt-get install -y libsqlite3-dev
+sudo apt-get install -y libssl-dev
+sudo apt-get install -y elasticsearch
 
 # needed for Alien::RRDtool in Task::Munin
-apt-get install -y pkg-config 
-apt-get install -y libglib2.0-dev
-apt-get install -y libcairo-dev
-apt-get install -y libpango1.0-dev
+sudo apt-get install -y pkg-config 
+sudo apt-get install -y libglib2.0-dev
+sudo apt-get install -y libcairo-dev
+sudo apt-get install -y libpango1.0-dev
 
 
 # MySQL
@@ -42,7 +42,7 @@ echo "copying bash_profile"
 cp /vagrant/bash_profile ~/.bash_profile
 cp /vagrant/gitconfig ~/.gitconfig
 echo "Result: $?"
-echo 'perl-maven' > /etc/hostname
+echo 'perl-maven' | sudo tee /etc/hostname
 
 # apt-get install -y apache2
 # if ! [ -L /var/www ]; then
@@ -50,5 +50,5 @@ echo 'perl-maven' > /etc/hostname
 #   ln -fs /vagrant /var/www
 # fi
 
-apt-get clean
+sudo apt-get clean
 


### PR DESCRIPTION
Hi Gabor,

I am sending you this pull request regarding your issue:

TODO fix copying bash_profile gitconfig examples 

By default, provision scripts are executed as privileged user in Vagrant, so config files from 
boostrap.sh will get copied to: /root.

To circumvent this, add “:privileged => false” option to  shell provisioner for provision scripts in Vagrantfile.

When running scripts with this option, make sure to add sudo to all commands that require superuser privileges.

For more information, please see:

https://github.com/mitchellh/vagrant/pull/1370
https://docs.vagrantup.com/v2/provisioning/shell.html
